### PR TITLE
Overriding timeout based on the label

### DIFF
--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -57,7 +57,6 @@ class IQERunner:
         self.pr_number = pr_number
 
         self.component_name = os.environ.get("BONFIRE_COMPONENT_NAME") or os.environ.get("COMPONENT_NAME")
-        self.iqe_cji_timeout = int(fuzzydate.to_seconds(os.environ.get("IQE_CJI_TIMEOUT", "10min")))
         self.iqe_env = os.environ.get("IQE_ENV", "clowder_smoke")
         self.iqe_image_tag = os.environ.get("IQE_IMAGE_TAG", "")
         self.iqe_plugins = os.environ.get("IQE_PLUGINS", "")
@@ -116,11 +115,17 @@ class IQERunner:
         return iqe_marker_expression
 
     @cached_property
+    def iqe_cji_timeout(self) -> int:
+        if "full-run-smoke-tests" in self.pr_labels:
+            return int(fuzzydate.to_seconds("5h"))
+        else:
+            return int(fuzzydate.to_seconds(os.environ.get("IQE_CJI_TIMEOUT", "10min")))
+
+    @cached_property
     def pr_labels(self) -> set[str]:
         if self.check:
             return set(os.environ.get("PR_LABELS", "").split()) or {"hot-fix-smoke-tests", "bug"}
 
-        return get_pr_labels(self.pr_number)
 
     @property
     def container(self) -> t.Any:

--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -116,10 +116,11 @@ class IQERunner:
 
     @cached_property
     def iqe_cji_timeout(self) -> int:
+        timeout = fuzzydate.to_seconds(os.environ.get("IQE_CJI_TIMEOUT", "10min"))
         if "full-run-smoke-tests" in self.pr_labels:
-            return int(fuzzydate.to_seconds("5h"))
-        else:
-            return int(fuzzydate.to_seconds(os.environ.get("IQE_CJI_TIMEOUT", "10min")))
+            timeout = fuzzydate.to_seconds("5h")
+
+        return int(timeout)
 
     @cached_property
     def pr_labels(self) -> set[str]:

--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -116,9 +116,14 @@ class IQERunner:
 
     @cached_property
     def iqe_cji_timeout(self) -> int:
-        timeout = fuzzydate.to_seconds(os.environ.get("IQE_CJI_TIMEOUT", "10min"))
+        try:
+            timeout = fuzzydate.to_seconds(os.environ.get("IQE_CJI_TIMEOUT", "2h"))
+        except (TypeError, ValueError) as exc:
+            print(f"{exc}. Using default value of 2h")
+            timeout = 2 * 60 * 60
+
         if "full-run-smoke-tests" in self.pr_labels:
-            timeout = fuzzydate.to_seconds("5h")
+            timeout = 5 * 60 * 60
 
         return int(timeout)
 

--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -126,6 +126,8 @@ class IQERunner:
         if self.check:
             return set(os.environ.get("PR_LABELS", "").split()) or {"hot-fix-smoke-tests", "bug"}
 
+        return get_pr_labels(self.pr_number)
+
     @property
     def container(self) -> t.Any:
         if self.pod is None:

--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -126,7 +126,6 @@ class IQERunner:
         if self.check:
             return set(os.environ.get("PR_LABELS", "").split()) or {"hot-fix-smoke-tests", "bug"}
 
-
     @property
     def container(self) -> t.Any:
         if self.pod is None:

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -99,11 +99,13 @@ def parse_args() -> argparse.Namespace:
 
     return parser.parse_args()
 
+
 def override_timeout_based_on_label(labels: set[str]) -> str:
     if "full-run-smoke-tests" in labels:
         return "5h"
     else:
         return os.environ.get("DEPLOY_TIMEOUT", 900)
+
 
 def get_pr_labels(
     pr_number: str,

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -99,6 +99,11 @@ def parse_args() -> argparse.Namespace:
 
     return parser.parse_args()
 
+def override_timeout_based_on_label(labels: set[str]) -> str:
+    if "full-run-smoke-tests" in labels:
+        return "5h"
+    else:
+        return os.environ.get("DEPLOY_TIMEOUT", 900)
 
 def get_pr_labels(
     pr_number: str,
@@ -131,12 +136,12 @@ def main() -> None:
     components_with_resources = os.environ.get("COMPONENTS_W_RESOURCES", "").split()
     components_with_resources_arg = chain.from_iterable(("--no-remove-resources", component) for component in components_with_resources)
     deploy_frontends = os.environ.get("DEPLOY_FRONTENDS") or "false"
-    deploy_timeout = os.environ.get("DEPLOY_TIMEOUT", 900)
     extra_deploy_args = os.environ.get("EXTRA_DEPLOY_ARGS", "")
     optional_deps_method = os.environ.get("OPTIONAL_DEPS_METHOD", "hybrid")
     ref_env = os.environ.get("REF_ENV", "insights-production")
     pr_number = os.environ.get("PR_NUMBER", "")
     labels = get_pr_labels(pr_number)
+    deploy_timeout = override_timeout_based_on_label(labels)
     cred_params = []
 
     if "koku" in components:


### PR DESCRIPTION
This change will define the timeout to 5h if `full-run-smoke-tests` label is set.