### PR TITLE
Refactor deploy command parameters

### DIFF
--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -79,7 +79,7 @@ def get_run_identifier() -> str:
         CHECK_RUN_ID not set     --> "c91a0f3d-4dbe-4b3b-9e5d-92b542f9f9f7"
     """
     check_run_id = os.environ.get("CHECK_RUN_ID")
-    return str(check_run_id) if check_run_id else str(uuid.uuid4())
+    return str(check_run_id) if check_run_id else uuid.uuid4().hex[:8]
 
 
 def get_component_options(components: list[Component], pr_number: str | None = None) -> list[str]:

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -215,7 +215,7 @@ def main() -> None:
             display("PR is not labeled to run tests in Konflux")
             return
 
-    for secret in ["koku-aws", "koku-gcp", "koku-oci"]:
+    for secret in ["koku-aws", "koku-gcp"]:
         cmd = f"oc get secret {secret} -o yaml -n ephemeral-base | grep -v '^\s*namespace:\s' | oc apply --namespace={namespace} -f -"
         display(cmd)
         subprocess.run(cmd, shell=True)

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -72,7 +72,7 @@ class Snapshot(BaseModel):
 def get_run_identifier() -> str:
     """Return the CHECK_RUN_ID used to identify this run.
 
-    If CHECK_RUN_ID is unset or falsy, return a random string to ensure uniqueness.
+    If CHECK_RUN_ID is unset or falsy, return a short, base64-encoded random string.
 
     Example:
         CHECK_RUN_ID=31510716818 --> "31510716818"

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import typing as t
 import urllib.request
+import uuid
 
 from itertools import chain
 from urllib.error import HTTPError
@@ -71,20 +72,14 @@ class Snapshot(BaseModel):
 def get_run_identifier() -> str:
     """Return the CHECK_RUN_ID used to identify this run.
 
-    Default to 1 if CHECK_RUN_ID is unset or falsy value.
+    If CHECK_RUN_ID is unset or falsy, return a random string to ensure uniqueness.
 
     Example:
-        31510716818 --> "31510716818"
+        CHECK_RUN_ID=31510716818 --> "31510716818"
+        CHECK_RUN_ID not set     --> "c91a0f3d-4dbe-4b3b-9e5d-92b542f9f9f7"
     """
-
-    check_run_id = os.environ.get("CHECK_RUN_ID") or "1"
-    try:
-        run_id = str(check_run_id)
-    except TypeError:
-        display("There was a problem with {check_run_id=}. Using default value of 1.")
-        run_id = "1"
-
-    return run_id
+    check_run_id = os.environ.get("CHECK_RUN_ID")
+    return str(check_run_id) if check_run_id else str(uuid.uuid4())
 
 
 def get_component_options(components: list[Component], pr_number: str | None = None) -> list[str]:

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -114,10 +114,8 @@ def get_component_options(components: list[Component], pr_number: str | None = N
         ))
 
         if component_name == "koku":
-            # IMAGE_TAG used as tag suffix (not related to image path)
-            image_tag = os.environ.get("IMAGE_TAG", f"{prefix}{revision}")
             result.append("--set-parameter")
-            result.append(f"{component_name}/SCHEMA_SUFFIX=_{image_tag}_{build_number}")
+            result.append(f"{component_name}/SCHEMA_SUFFIX=_{prefix}{revision}_{build_number}")
 
     return result
 

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -99,12 +99,18 @@ def get_component_options(components: list[Component], pr_number: str | None = N
         image = component.container_image.image
 
         result.extend((
-            "--set-template-ref", f"{component_name}={component.source.git.revision}",
-            "--set-parameter", f"{component_name}/IMAGE={image}",
-            "--set-parameter", f"{component_name}/IMAGE_TAG={prefix}{revision}",
-            "--set-parameter", f"{component_name}/DBM_IMAGE={image}",
-            "--set-parameter", f"{component_name}/DBM_IMAGE_TAG={prefix}{revision}",
-            "--set-parameter", f"{component_name}/DBM_INVOCATION={secrets.randbelow(100)}",
+            "--set-template-ref",
+            f"{component_name}={component.source.git.revision}",
+            "--set-parameter",
+            f"{component_name}/IMAGE={image}",
+            "--set-parameter",
+            f"{component_name}/IMAGE_TAG={prefix}{revision}",
+            "--set-parameter",
+            f"{component_name}/DBM_IMAGE={image}",
+            "--set-parameter",
+            f"{component_name}/DBM_IMAGE_TAG={prefix}{revision}",
+            "--set-parameter",
+            f"{component_name}/DBM_INVOCATION={secrets.randbelow(100)}",
         ))
 
         if component_name == "koku":


### PR DESCRIPTION
Refactor deploy command parameters and remove unused credential settings

## Summary by Sourcery

Refactor the deploy command to streamline parameter handling, remove unused credential settings, and introduce dynamic Helm parameters for schema, image settings, and invocation control.

Enhancements:
- Remove unused AWS/GCP/OCI credential parameters from the deploy invocation
- Add dynamic Helm parameters for schema suffix, DBM image settings, and general image values based on environment variables
- Generate a random invocation ID for each deploy to force Helm upgrades
- Introduce the --no-single-replicas flag to prevent single-replica deployments
- Simplify the get_component_options call to only require the PR number