### PR TITLE
Add IQE_PARALLEL_ENABLED environment variable to deployment script

### DIFF
--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -91,7 +91,8 @@ class IQERunner:
         job_name = f"JOB_NAME={self.job_name}"
         build_number = f"BUILD_NUMBER={self.build_number}"
         build_url = f"BUILD_URL={self.build_url}"
-        env_var_params = [job_name, build_number, build_url]
+        iqe_parallel_enabled = f"IQE_PARALLEL_ENABLED=false"
+        env_var_params = [job_name, build_number, build_url, iqe_parallel_enabled]
         return chain.from_iterable(("--env-var", var) for var in env_var_params)
 
     @cached_property

--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -91,7 +91,7 @@ class IQERunner:
         job_name = f"JOB_NAME={self.job_name}"
         build_number = f"BUILD_NUMBER={self.build_number}"
         build_url = f"BUILD_URL={self.build_url}"
-        iqe_parallel_enabled = f"IQE_PARALLEL_ENABLED=false"
+        iqe_parallel_enabled = "IQE_PARALLEL_ENABLED=false"
         env_var_params = [job_name, build_number, build_url, iqe_parallel_enabled]
         return chain.from_iterable(("--env-var", var) for var in env_var_params)
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Include IQE_PARALLEL_ENABLED=false in the environment variables passed by the deployment script