### PR TITLE
[COST-6310] Add schema suffix generation based on CHECK_RUN_ID and REVISION

### DIFF
--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -70,8 +70,7 @@ class IQERunner:
     def schema_suffix(self) -> str:
         revision = os.environ.get("REVISION", "")[:7]
         prefix = f"pr-{self.pr_number}-" if self.pr_number else ""
-        suffix = f"{self.component_name}/SCHEMA_SUFFIX=_{prefix}{revision}_{self.get_run_identifier}"
-        return suffix
+        return f"{self.component_name}/SCHEMA_SUFFIX=_{prefix}{revision}_{self.get_run_identifier}"
 
     @cached_property
     def build_url(self) -> str:

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -9,7 +9,6 @@ import subprocess
 import sys
 import typing as t
 import urllib.request
-import uuid
 
 from itertools import chain
 from urllib.error import HTTPError
@@ -70,16 +69,13 @@ class Snapshot(BaseModel):
 
 
 def get_run_identifier() -> str:
-    """Return the CHECK_RUN_ID used to identify this run.
-
-    If CHECK_RUN_ID is unset or falsy, return a short, base64-encoded random string.
+    """Get the run-id from the pipeline run name
 
     Example:
-        CHECK_RUN_ID=31510716818 --> "31510716818"
-        CHECK_RUN_ID not set     --> "c91a0f3d-4dbe-4b3b-9e5d-92b542f9f9f7"
+        koku-ci-5rxkp --> 5rxkp
     """
-    check_run_id = os.environ.get("CHECK_RUN_ID")
-    return str(check_run_id) if check_run_id else uuid.uuid4().hex[:8]
+    pipeline_run_name = os.environ.get("PIPELINE_RUN_NAME")
+    return pipeline_run_name.rsplit("-", 1)[1]
 
 
 def get_component_options(components: list[Component], pr_number: str | None = None) -> list[str]:


### PR DESCRIPTION
## Summary by Sourcery

Generate a schema suffix for IQE deployments by combining PR number, component name, git revision and run identifier, and update run identifier handling.

Enhancements:
- Replace the build_number property with get_run_identifier to return the full CHECK_RUN_ID or an 8-character random string when unset
- Add a schema_suffix property that constructs a SCHEMA_SUFFIX string using the component name, PR number, truncated REVISION, and run identifier
- Include the generated schema_suffix in the IQE job environment variables argument list