### PR TITLE
use the NS_REQUESTER which is defined as the pipeline-run-name

### DIFF
--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -40,7 +40,7 @@ class IQERunner:
         self.iqe_requirements = os.environ.get("IQE_REQUIREMENTS", "")
         self.iqe_requirements_priority = os.environ.get("IQE_REQUIREMENTS_PRIORITY", "")
         self.iqe_test_importance = os.environ.get("IQE_TEST_IMPORTANCE", "")
-        self.pipeline_run_name = os.environ.get("PIPELINE_RUN_NAME") or ""
+        self.pipeline_run_name = os.environ.get("NS_REQUESTER") or ""
         self.selenium = os.environ.get("IQE_SELENIUM", "")
 
     @cached_property

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -74,7 +74,7 @@ def get_run_identifier() -> str:
     Example:
         koku-ci-5rxkp --> 5rxkp
     """
-    pipeline_run_name = os.environ.get("PIPELINE_RUN_NAME")
+    pipeline_run_name = os.environ.get("NS_REQUESTER")
     return pipeline_run_name.rsplit("-", 1)[1]
 
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Switch deployment scripts to use the NS_REQUESTER environment variable instead of PIPELINE_RUN_NAME for pipeline run naming and identification