### PR TITLE
switch back to PIPELINE_RUN_NAME

### DIFF
--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -40,7 +40,7 @@ class IQERunner:
         self.iqe_requirements = os.environ.get("IQE_REQUIREMENTS", "")
         self.iqe_requirements_priority = os.environ.get("IQE_REQUIREMENTS_PRIORITY", "")
         self.iqe_test_importance = os.environ.get("IQE_TEST_IMPORTANCE", "")
-        self.pipeline_run_name = os.environ.get("NS_REQUESTER")
+        self.pipeline_run_name = os.environ.get("PIPELINE_RUN_NAME")
         self.selenium = os.environ.get("IQE_SELENIUM", "")
 
     @cached_property

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -74,7 +74,7 @@ def get_run_identifier() -> str:
     Example:
         koku-ci-5rxkp --> 5rxkp
     """
-    return os.environ.get("NS_REQUESTER").rsplit("-", 1)[1]
+    return os.environ.get("PIPELINE_RUN_NAME").rsplit("-", 1)[1]
 
 
 def get_component_options(components: list[Component], pr_number: str | None = None) -> list[str]:


### PR DESCRIPTION
the PIPELINE_RUN_NAME wasn't available. This [PR](https://github.com/project-koku/koku-ci/pull/27) adds it.

## Summary by Sourcery

Switch deploy scripts to use the PIPELINE_RUN_NAME environment variable for pipeline run identification instead of NS_REQUESTER

Enhancements:
- Update deploy-iqe-cji.py to source pipeline_run_name from PIPELINE_RUN_NAME
- Modify deploy.py’s get_run_identifier function to parse PIPELINE_RUN_NAME instead of NS_REQUESTER