### PR TITLE
pass SNAPSHOT into the deploy-iqe script

### DIFF
--- a/files/bin/models.py
+++ b/files/bin/models.py
@@ -1,0 +1,53 @@
+from collections.abc import MutableMapping
+from typing import Any
+
+from pydantic import AnyUrl
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+from pydantic import model_validator
+
+
+class Git(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    url: AnyUrl
+    revision: str
+
+
+class Source(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    git: Git
+
+
+class ContainerImage(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    image: str
+    sha: str
+
+
+class Component(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    container_image: ContainerImage = Field(alias="containerImage")
+    source: Source
+
+    @model_validator(mode="before")
+    @classmethod
+    def container_image_validator(cls, data: Any) -> Any:
+        if not isinstance(data, MutableMapping):
+            raise ValueError(f"{data} is not of mapping type")
+
+        image, sha = data["containerImage"].split("@sha256:")
+        data["containerImage"] = ContainerImage(image=image, sha=sha)
+        return data
+
+
+class Snapshot(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    application: str
+    components: list[Component]


### PR DESCRIPTION
## Summary by Sourcery

Extract data models to a shared module and update deployment scripts to use structured snapshot data, adding SNAPSHOT support for IQE deployments

New Features:
- Allow passing a SNAPSHOT environment variable into deploy-iqe-cji for structured release data and validate its JSON

Enhancements:
- Extract Pydantic models (Git, Source, ContainerImage, Component, Snapshot) into a shared models module
- Refactor deploy.py and deploy-iqe-cji.py to import and use the shared models
- Derive schema suffix in deploy-iqe-cji from the first component of the snapshot instead of REVISION env var
- Simplify component options assembly in deploy.py to use extend and streamline type hints