### PR TITLE
Increase timeout for full-run smoke tests to 8 hours

### DIFF
--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -86,7 +86,7 @@ def get_timeout(env_var: str, labels: set[str] | None = None) -> int:
         timeout = 2 * 60 * 60
 
     if labels and "full-run-smoke-tests" in labels:
-        timeout = 6 * 60 * 60
+        timeout = 8 * 60 * 60
 
     return int(timeout)
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Increase full-run smoke test timeout from 6 hours to 8 hours