### PR TITLE
Remove toggle for Konflux tests in deployment script

### DIFF
--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -151,9 +151,8 @@ def main() -> None:
         display("PR labeled to skip smoke tests")
         return
 
-    if "koku" in snapshot_components:
-        if "smokes-required" in labels and not any(label.endswith("smoke-tests") for label in labels):
-            sys.exit("Missing smoke tests labels.")
+    if "koku" in snapshot_components and "smokes-required" in labels and not any(label.endswith("smoke-tests") for label in labels):
+        sys.exit("Missing smoke tests labels.")
 
     for secret in ["koku-aws", "koku-gcp"]:
         cmd = f"oc get secret {secret} -o yaml -n ephemeral-base | grep -v '^\s*namespace:\s' | oc apply --namespace={namespace} -f -"

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -139,7 +139,8 @@ def main() -> None:
     components = os.environ.get("COMPONENTS", "").split()
     components_arg = chain.from_iterable(("--component", component) for component in components)
     components_with_resources = os.environ.get("COMPONENTS_W_RESOURCES", "").split()
-    components_with_resources_arg = chain.from_iterable(("--no-remove-resources", component) for component in components_with_resources)
+    components_with_resources_arg = chain.from_iterable(
+        ("--no-remove-resources", component) for component in components_with_resources)
     snapshot_components = {component.name for component in snapshot.components}
     deploy_frontends = os.environ.get("DEPLOY_FRONTENDS") or "false"
     deploy_timeout = get_timeout("DEPLOY_TIMEOUT", labels)
@@ -147,11 +148,17 @@ def main() -> None:
     optional_deps_method = os.environ.get("OPTIONAL_DEPS_METHOD", "hybrid")
     ref_env = os.environ.get("REF_ENV", "insights-production")
 
+    # If the 'run-jenkins-tests' label is present, skip Konflux tests and run Jenkins tests instead.
+    if "run-jenkins-tests" in labels:
+        display("PR labeled to run Jenkins tests instead of Konflux")
+        return
+
     if "ok-to-skip-smokes" in labels:
         display("PR labeled to skip smoke tests")
         return
 
-    if "koku" in snapshot_components and "smokes-required" in labels and not any(label.endswith("smoke-tests") for label in labels):
+    if "koku" in snapshot_components and "smokes-required" in labels and not any(
+            label.endswith("smoke-tests") for label in labels):
         sys.exit("Missing smoke tests labels.")
 
     for secret in ["koku-aws", "koku-gcp"]:

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -155,16 +155,6 @@ def main() -> None:
         if "smokes-required" in labels and not any(label.endswith("smoke-tests") for label in labels):
             sys.exit("Missing smoke tests labels.")
 
-        # Skip Konflux tests unless explicitly labeled.
-        # This prevents tests from running in both Jenkins and Konflux and can be
-        # removed when Konflux increases the integration test timeout and
-        # Jenkins tests are disabled.
-        #
-        # https://issues.redhat.com/browse/KONFLUX-5449
-        if "run-konflux-tests" not in labels:
-            display("PR is not labeled to run tests in Konflux")
-            return
-
     for secret in ["koku-aws", "koku-gcp"]:
         cmd = f"oc get secret {secret} -o yaml -n ephemeral-base | grep -v '^\s*namespace:\s' | oc apply --namespace={namespace} -f -"
         display(cmd)


### PR DESCRIPTION
## Summary by Sourcery

Refactor the deployment script to eliminate the Konflux tests toggle, streamline label retrieval, and introduce a Jenkins-specific skip label.

New Features:
- Add support for skipping test execution via a 'run-jenkins-tests' PR label

Enhancements:
- Only fetch PR labels when a PR number is provided
- Consolidate smoke tests label validation into a single conditional
- Remove the 'run-konflux-tests' guard and related toggle logic

Deployment:
- Update deploy.py to drop the Konflux test toggle and integrate the new Jenkins skip label