### PR TITLE
Fix S3 upload script to correctly reference artifacts key in URL

### DIFF
--- a/files/bin/upload-to-s3.sh
+++ b/files/bin/upload-to-s3.sh
@@ -9,7 +9,7 @@ main() {
     local bucket="${BUCKET:-rh-artifacts-bucket}"
 
 
-    aws s3 cp --recursive /artifacts "s3://${bucket}/$(artifacts_key)" --quiet
+    aws s3 cp --recursive /artifacts "s3://${bucket}/${artifacts_key}" --quiet
     url="https://s3.console.aws.amazon.com/s3/buckets/${bucket}?region=${aws_default_region}&prefix=${artifacts_key}/&showversions=false"
     echo -n "${url//'\n'}"
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Use the artifacts_key variable instead of a command substitution when constructing the S3 upload path in upload-to-s3.sh