### PR TITLE
Update script to avoid key exposure

### DIFF
--- a/files/bin/upload-to-s3.sh
+++ b/files/bin/upload-to-s3.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 main() {
 


### PR DESCRIPTION
## Summary by Sourcery

Avoid AWS key exposure by disabling the bash debug flag in the upload-to-s3 script and update the default S3 bucket name

Enhancements:
- Remove the '-x' flag from the script shebang to prevent secrets from being printed
- Change the default S3 bucket to 'hccm-konflux-artifacts'