### PR TITLE
Pr cron flow refinement

### DIFF
--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -259,7 +259,7 @@ class IQERunner:
             "--for", "condition=JobInvocationComplete",
             "--namespace", self.namespace,
             f"cji/{self.component_name}",
-        ])
+        ]) # fmt: off
 
         self.check_cji_jobs()
 

--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -235,8 +235,7 @@ class IQERunner:
                 display("PR is not labeled to run tests in Konflux")
                 return
 
-            if "smokes-required" in self.pr_labels and not any(
-                    label.endswith("smoke-tests") for label in self.pr_labels):
+            if "smokes-required" in self.pr_labels and not any(label.endswith("smoke-tests") for label in self.pr_labels):
                 sys.exit("Missing smoke tests labels.")
         else:
             # No PR labels — likely a nightly or manual snapshot run
@@ -259,7 +258,7 @@ class IQERunner:
             "--for", "condition=JobInvocationComplete",
             "--namespace", self.namespace,
             f"cji/{self.component_name}",
-        ]) # fmt: off
+        ])  # fmt: off
 
         self.check_cji_jobs()
 


### PR DESCRIPTION
## Summary by Sourcery

Distinguish pull request runs from nightly/manual cron runs in smoke and Konflux test workflows, ensuring full smoke tests are always executed on non-PR runs while preserving label-based skips for PRs.

Enhancements:
- Add conditional branches in deploy.py and deploy-iqe-cji.py to detect absence of PR number or labels and treat those as nightly/manual runs
- Log informational messages and proceed with full smoke tests when no PR number or labels are found
- Preserve existing label-driven skips for smoke tests and Konflux tests on PR-triggered runs

Chores:
- Fix minor formatting around the # fmt: off annotation in deploy-iqe-cji.py