### PR TITLE
Debuging labels fix

### DIFF
--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -218,21 +218,17 @@ class IQERunner:
         print(f"\nAll jobs succeeded: {job_map}", flush=True)
 
     def run(self) -> None:
-        display("Reached updated version of the script - labels check starting...")
-        display(f"labels: {self.pr_labels}")
-        # If it's a PR and has the "ok-to-skip-smokes" label
-        if self.pr_labels and "ok-to-skip-smokes" in self.pr_labels:
-            display("PR labeled to skip smoke tests")
-            return
-
         # Skip Konflux tests unless explicitly labeled.
         # This prevents tests from running in both Jenkins and Konflux and can be
         # removed when Konflux increases the integration test timeout and
         # Jenkins tests are disabled.
         #
         # https://issues.redhat.com/browse/KONFLUX-5449
-        if self.pr_labels is not None:
-            # This is likely a PR run
+        if self.pr_labels:
+            if "ok-to-skip-smokes" in self.pr_labels:
+                display("PR labeled to skip smoke tests")
+                return
+
             if "run-konflux-tests" not in self.pr_labels:
                 display("PR is not labeled to run tests in Konflux")
                 return
@@ -240,7 +236,7 @@ class IQERunner:
             if "smokes-required" in self.pr_labels and not any(label.endswith("smoke-tests") for label in self.pr_labels):
                 sys.exit("Missing smoke tests labels.")
         else:
-            # No PR labels — likely a nightly or manual snapshot run
+            # Labels are empty (nightly/manual snapshot scenario)
             display("[INFO] No PR labels found. Assuming this is a nightly or manual test run.")
             display("[INFO] Proceeding with full smoke tests...")
 

--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -218,6 +218,8 @@ class IQERunner:
         print(f"\nAll jobs succeeded: {job_map}", flush=True)
 
     def run(self) -> None:
+        display("Reached updated version of the script - labels check starting...")
+        display(f"labels: {self.pr_labels}")
         # If it's a PR and has the "ok-to-skip-smokes" label
         if self.pr_labels and "ok-to-skip-smokes" in self.pr_labels:
             display("PR labeled to skip smoke tests")

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -122,6 +122,7 @@ def display(command: str | Sequence[Any]) -> None:
 
 
 def main() -> None:
+    display("Deploying snapshot...")
     args = parse_args()
     namespace = args.namespace
     requester = args.requester
@@ -146,7 +147,7 @@ def main() -> None:
     extra_deploy_args = os.environ.get("EXTRA_DEPLOY_ARGS", "")
     optional_deps_method = os.environ.get("OPTIONAL_DEPS_METHOD", "hybrid")
     ref_env = os.environ.get("REF_ENV", "insights-production")
-
+    display(f"pr_number: {pr_number}")
     if pr_number:
         if "ok-to-skip-smokes" in labels:
             display("PR labeled to skip smoke tests")

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -122,7 +122,6 @@ def display(command: str | Sequence[Any]) -> None:
 
 
 def main() -> None:
-    display("Deploying snapshot...")
     args = parse_args()
     namespace = args.namespace
     requester = args.requester
@@ -147,7 +146,6 @@ def main() -> None:
     extra_deploy_args = os.environ.get("EXTRA_DEPLOY_ARGS", "")
     optional_deps_method = os.environ.get("OPTIONAL_DEPS_METHOD", "hybrid")
     ref_env = os.environ.get("REF_ENV", "insights-production")
-    display(f"pr_number: {pr_number}")
     if pr_number:
         if "ok-to-skip-smokes" in labels:
             display("PR labeled to skip smoke tests")


### PR DESCRIPTION
## Summary by Sourcery

Refine PR label handling in IQE CJI deployment script by consolidating skip‐smoke and Konflux test checks under a single label‐presence branch, clarify empty‐label messaging for nightly/manual runs, and remove an extraneous blank line in the main deploy script.

Bug Fixes:
- Ensure the “ok-to-skip-smokes” label is only evaluated when PR labels are present to prevent unintended test skipping.

Enhancements:
- Combine and streamline PR label checks for Konflux and smoke tests in deploy-iqe-cji.py.
- Update comment to clearly describe the nightly/manual snapshot scenario when labels are empty.
- Clean up whitespace by removing an extra blank line in deploy.py.