### PR TITLE
fix var name

### DIFF
--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -57,10 +57,10 @@ class IQERunner:
     def get_check_run_identifier(self) -> str:
         """Get a unique build identifier for Ibutsu dashboard grouping.
 
-        - If IS_SCHEDULE_JOB is True: return date in YYMMDD format (e.g., 250609)
+        - If IS_SCHEDULED_TEST_JOB is True: return date in YYMMDD format (e.g., 250609)
         - Else: fallback to CHECK_RUN_ID[:5] or '1'
         """
-        is_schedule = os.environ.get("IS_SCHEDULE_JOB", "").lower() == "true"
+        is_schedule = os.environ.get("IS_SCHEDULED_TEST_JOB", "").lower() == "true"
         if is_schedule:
             return datetime.utcnow().strftime("%y%m%d")
 


### PR DESCRIPTION
Change Var to actually match whats in https://github.com/project-koku/koku-ci/pull/43

## Summary by Sourcery

Bug Fixes:
- Rename IS_SCHEDULE_JOB to IS_SCHEDULED_TEST_JOB in get_check_run_identifier logic and docstring