### PR TITLE
Fix var name - part 2

### DIFF
--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -25,10 +25,10 @@ from pydantic import ValidationError
 def get_check_run_identifier() -> str:
     """Get a unique build identifier for Ibutsu dashboard grouping.
 
-    - If IS_SCHEDULE_JOB is True: return date in YYMMDD format (e.g., 250609)
+    - If IS_SCHEDULED_TEST_JOB is True: return date in YYMMDD format (e.g., 250609)
     - Else: fallback to CHECK_RUN_ID[:5] or '1'
     """
-    is_schedule = os.environ.get("IS_SCHEDULE_JOB", "").lower() == "true"
+    is_schedule = os.environ.get("IS_SCHEDULED_TEST_JOB", "").lower() == "true"
     if is_schedule:
         return datetime.utcnow().strftime("%y%m%d")
 


### PR DESCRIPTION
Change Var to actually match whats in https://github.com/project-koku/koku-ci/pull/43

## Summary by Sourcery

Fix the scheduled test job environment variable name in the deploy script to match the expected configuration.

Bug Fixes:
- Rename the IS_SCHEDULE_JOB environment variable to IS_SCHEDULED_TEST_JOB in get_check_run_identifier
- Update the function docstring to reference IS_SCHEDULED_TEST_JOB