### PR TITLE
Refactor test execution logic to prioritize Konflux tests over Jenkins

### DIFF
--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -228,22 +228,17 @@ class IQERunner:
         print(f"\nAll jobs succeeded: {job_map}", flush=True)
 
     def run(self) -> None:
-        # Skip Konflux tests unless explicitly labeled.
-        # This prevents tests from running in both Jenkins and Konflux and can be
-        # removed when Konflux increases the integration test timeout and
-        # Jenkins tests are disabled.
-        #
-        # https://issues.redhat.com/browse/KONFLUX-5449
         if self.pr_labels:
+            if "run-jenkins-tests" in self.pr_labels:
+                display("PR labeled to run Jenkins tests instead of Konflux")
+                return
+
             if "ok-to-skip-smokes" in self.pr_labels:
                 display("PR labeled to skip smoke tests")
                 return
 
-            if "run-konflux-tests" not in self.pr_labels:
-                display("PR is not labeled to run tests in Konflux")
-                return
-
-            if "smokes-required" in self.pr_labels and not any(label.endswith("smoke-tests") for label in self.pr_labels):
+            if "smokes-required" in self.pr_labels and not any(
+                    label.endswith("smoke-tests") for label in self.pr_labels):
                 sys.exit("Missing smoke tests labels.")
         else:
             # Labels are empty (nightly/manual snapshot scenario)

--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -237,8 +237,7 @@ class IQERunner:
                 display("PR labeled to skip smoke tests")
                 return
 
-            if "smokes-required" in self.pr_labels and not any(
-                    label.endswith("smoke-tests") for label in self.pr_labels):
+            if "smokes-required" in self.pr_labels and not any(label.endswith("smoke-tests") for label in self.pr_labels):
                 sys.exit("Missing smoke tests labels.")
         else:
             # Labels are empty (nightly/manual snapshot scenario)


### PR DESCRIPTION
## Summary by Sourcery

Refactor the CI test dispatch logic to default to Konflux-driven execution, only invoking Jenkins when explicitly requested, while preserving and refining the smoke-test skip and enforcement labels.

Enhancements:
- Require the "run-jenkins-tests" PR label to trigger Jenkins tests, defaulting to Konflux otherwise
- Retain the "ok-to-skip-smokes" label behavior to skip smoke tests
- Ensure that "smokes-required" PRs include a valid smoke-test label before proceeding