### PR TITLE
Cost 6462 check labels before deploying

### DIFF
--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -228,21 +228,11 @@ class IQERunner:
         print(f"\nAll jobs succeeded: {job_map}", flush=True)
 
     def run(self) -> None:
-        if self.pr_labels:
-            if "run-jenkins-tests" in self.pr_labels:
-                display("PR labeled to run Jenkins tests instead of Konflux")
-                return
-
-            if "ok-to-skip-smokes" in self.pr_labels:
-                display("PR labeled to skip smoke tests")
-                return
-
-            if "smokes-required" in self.pr_labels and not any(label.endswith("smoke-tests") for label in self.pr_labels):
-                sys.exit("Missing smoke tests labels.")
-        else:
-            # Labels are empty (nightly/manual snapshot scenario)
+        if not self.pr_labels:
             display("[INFO] No PR labels found. Assuming this is a scheduled or manual test run.")
             display("[INFO] Proceeding with full smoke tests...")
+
+        display("[INFO] Starting deploy. Label validation was already handled by Tekton.")
 
         self.run_pod()
 

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -142,21 +142,11 @@ def main() -> None:
     optional_deps_method = os.environ.get("OPTIONAL_DEPS_METHOD", "hybrid")
     ref_env = os.environ.get("REF_ENV", "insights-production")
 
-    if pr_number:
-        if "run-jenkins-tests" in labels:
-            display("PR labeled to run Jenkins tests instead of Konflux")
-            return
-
-        if "ok-to-skip-smokes" in labels:
-            display("PR labeled to skip smoke tests")
-            return
-
-        if "koku" in snapshot_components and "smokes-required" in labels and not any(label.endswith("smoke-tests") for label in labels):
-            sys.exit("Missing smoke tests labels.")
-
-    else:
-        display("[INFO] No PR number found. Assuming nightly/manual test run.")
+    if not pr_number:
+        display("[INFO] No PR number found. Assuming this is a scheduled or manual test run.")
         display("[INFO] Proceeding with full smoke tests...")
+
+    display("[INFO] Starting deploy. Label validation was already handled by Tekton.")
 
     for secret in ["koku-aws", "koku-gcp"]:
         cmd = f"oc get secret {secret} -o yaml -n ephemeral-base | grep -v '^\s*namespace:\s' | oc apply --namespace={namespace} -f -"

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -135,7 +135,6 @@ def main() -> None:
     components_arg = chain.from_iterable(("--component", component) for component in components)
     components_with_resources = os.environ.get("COMPONENTS_W_RESOURCES", "").split()
     components_with_resources_arg = chain.from_iterable(("--no-remove-resources", component) for component in components_with_resources)
-    snapshot_components = {component.name for component in snapshot.components}
     deploy_frontends = os.environ.get("DEPLOY_FRONTENDS") or "false"
     deploy_timeout = get_timeout("DEPLOY_TIMEOUT", labels)
     extra_deploy_args = os.environ.get("EXTRA_DEPLOY_ARGS", "")


### PR DESCRIPTION
## Summary by Sourcery

Remove in-script PR label validation and defer all label checks to Tekton, simplifying deploy logic across both deploy scripts.

Enhancements:
- Remove manual PR label checks for Jenkins tests, skipping smokes, and missing smoke-tests labels in deploy scripts
- Unify handling of missing PR number or labels to assume scheduled/manual runs with consistent info messages
- Add a generic info message indicating that label validation is now performed by Tekton