### PR TITLE
Put skip smokes check back

### DIFF
--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -232,6 +232,10 @@ class IQERunner:
             display("[INFO] No PR labels found. Assuming this is a scheduled or manual test run.")
             display("[INFO] Proceeding with full smoke tests...")
 
+        if "ok-to-skip-smokes" in self.pr_labels:
+            display("[INFO] PR labeled with 'ok-to-skip-smokes'. Skipping smoke tests.")
+            return
+
         display("[INFO] Starting deploy. Label validation was already handled by Tekton.")
 
         self.run_pod()

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -141,6 +141,10 @@ def main() -> None:
     optional_deps_method = os.environ.get("OPTIONAL_DEPS_METHOD", "hybrid")
     ref_env = os.environ.get("REF_ENV", "insights-production")
 
+    if "ok-to-skip-smokes" in labels:
+        display("[INFO] PR labeled with 'ok-to-skip-smokes'. Skipping deploy.")
+        return
+
     if not pr_number:
         display("[INFO] No PR number found. Assuming this is a scheduled or manual test run.")
         display("[INFO] Proceeding with full smoke tests...")

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -141,15 +141,13 @@ def main() -> None:
     optional_deps_method = os.environ.get("OPTIONAL_DEPS_METHOD", "hybrid")
     ref_env = os.environ.get("REF_ENV", "insights-production")
 
-    if "ok-to-skip-smokes" in labels:
-        display("[INFO] PR labeled with 'ok-to-skip-smokes'. Skipping deploy.")
-        return
-
-    if not pr_number:
+    if pr_number:
+        if "ok-to-skip-smokes" in labels:
+            display("[INFO] PR labeled with 'ok-to-skip-smokes'. Skipping deploy.")
+            return
+    else:
         display("[INFO] No PR number found. Assuming this is a scheduled or manual test run.")
         display("[INFO] Proceeding with full smoke tests...")
-
-    display("[INFO] Starting deploy. Label validation was already handled by Tekton.")
 
     for secret in ["koku-aws", "koku-gcp"]:
         cmd = f"oc get secret {secret} -o yaml -n ephemeral-base | grep -v '^\s*namespace:\s' | oc apply --namespace={namespace} -f -"


### PR DESCRIPTION
## Summary by Sourcery

Reintroduce the ability to skip smoke tests in the deployment pipelines when a PR is labeled 'ok-to-skip-smokes'.

New Features:
- Add logic in deploy.py to skip full smoke tests if the PR has the 'ok-to-skip-smokes' label
- Add logic in deploy-iqe-cji.py to skip smoke tests when the PR includes the 'ok-to-skip-smokes' label