### PR TITLE
Revert changes: restore repo to commit d032050

### DIFF
--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -228,21 +228,15 @@ class IQERunner:
         print(f"\nAll jobs succeeded: {job_map}", flush=True)
 
     def run(self) -> None:
-        if self.pr_labels:
-            if "run-jenkins-tests" in self.pr_labels:
-                display("PR labeled to run Jenkins tests instead of Konflux")
-                return
-
-            if "ok-to-skip-smokes" in self.pr_labels:
-                display("PR labeled to skip smoke tests")
-                return
-
-            if "smokes-required" in self.pr_labels and not any(label.endswith("smoke-tests") for label in self.pr_labels):
-                sys.exit("Missing smoke tests labels.")
-        else:
-            # Labels are empty (nightly/manual snapshot scenario)
+        if not self.pr_labels:
             display("[INFO] No PR labels found. Assuming this is a scheduled or manual test run.")
             display("[INFO] Proceeding with full smoke tests...")
+
+        if "ok-to-skip-smokes" in self.pr_labels:
+            display("[INFO] PR labeled with 'ok-to-skip-smokes'. Skipping smoke tests.")
+            return
+
+        display("[INFO] Starting deploy. Label validation was already handled by Tekton.")
 
         self.run_pod()
 

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -135,7 +135,6 @@ def main() -> None:
     components_arg = chain.from_iterable(("--component", component) for component in components)
     components_with_resources = os.environ.get("COMPONENTS_W_RESOURCES", "").split()
     components_with_resources_arg = chain.from_iterable(("--no-remove-resources", component) for component in components_with_resources)
-    snapshot_components = {component.name for component in snapshot.components}
     deploy_frontends = os.environ.get("DEPLOY_FRONTENDS") or "false"
     deploy_timeout = get_timeout("DEPLOY_TIMEOUT", labels)
     extra_deploy_args = os.environ.get("EXTRA_DEPLOY_ARGS", "")
@@ -143,19 +142,11 @@ def main() -> None:
     ref_env = os.environ.get("REF_ENV", "insights-production")
 
     if pr_number:
-        if "run-jenkins-tests" in labels:
-            display("PR labeled to run Jenkins tests instead of Konflux")
-            return
-
         if "ok-to-skip-smokes" in labels:
-            display("PR labeled to skip smoke tests")
+            display("[INFO] PR labeled with 'ok-to-skip-smokes'. Skipping deploy.")
             return
-
-        if "koku" in snapshot_components and "smokes-required" in labels and not any(label.endswith("smoke-tests") for label in labels):
-            sys.exit("Missing smoke tests labels.")
-
     else:
-        display("[INFO] No PR number found. Assuming nightly/manual test run.")
+        display("[INFO] No PR number found. Assuming this is a scheduled or manual test run.")
         display("[INFO] Proceeding with full smoke tests...")
 
     for secret in ["koku-aws", "koku-gcp"]:


### PR DESCRIPTION
## Summary by Sourcery

Revert recent label-handling changes and restore the repository to commit d032050 by removing Jenkins test flags, required smoke-test checks, and unused snapshot component logic from the deploy scripts

Chores:
- Revert PR label branches for Jenkins tests and smoke-test enforcement in deploy-iqe-cji.py
- Simplify label handling and info messaging for manual or scheduled runs in deploy-iqe-cji.py
- Remove snapshot_components calculation and related smoke-test checks from deploy.py