### PR TITLE
COST-7391: Fail PR checks when no labels are found

### DIFF
--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -265,8 +265,9 @@ class IQERunner:
 
             if "smokes-required" in self.pr_labels and not any(label.endswith("smoke-tests") for label in self.pr_labels):
                 sys.exit("Missing smoke tests labels.")
+        elif self.pr_number:
+            sys.exit(f"[ERROR] No labels found on PR #{self.pr_number}. Add a smoke test label (e.g., smoke-tests, ok-to-skip-smokes) to proceed.")
         else:
-            # Labels are empty (nightly/manual snapshot scenario)
             display("[INFO] No PR labels found. Assuming this is a scheduled or manual test run.")
             display("[INFO] Proceeding with full smoke tests...")
 

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -161,6 +161,30 @@ def get_pr_labels(
     return {item["name"] for item in data["labels"]}
 
 
+def _should_deploy(pr_number: str, labels: set[str] | list, snapshot_components: set[str]) -> bool:
+    """Check PR labels to determine whether the deploy should proceed."""
+    if pr_number:
+        if "run-jenkins-tests" in labels:
+            display("PR labeled to run Jenkins tests instead of Konflux")
+            return False
+
+        if "ok-to-skip-smokes" in labels:
+            display("PR labeled to skip smoke tests")
+            return False
+
+        if "koku" in snapshot_components and "smokes-required" in labels and not any(label.endswith("smoke-tests") for label in labels):
+            sys.exit("Missing smoke tests labels.")
+
+        if not labels:
+            sys.exit(f"[ERROR] No labels found on PR #{pr_number}. Add a smoke test label (e.g., smoke-tests, ok-to-skip-smokes) to proceed.")
+
+    else:
+        display("[INFO] No PR number found. Assuming nightly/manual test run.")
+        display("[INFO] Proceeding with full smoke tests...")
+
+    return True
+
+
 def display(command: str | Sequence[Any]) -> None:
     if isinstance(command, str):
         quoted = [command]
@@ -201,21 +225,8 @@ def main() -> None:
     optional_deps_method = os.environ.get("OPTIONAL_DEPS_METHOD", "hybrid")
     ref_env = os.environ.get("REF_ENV", "insights-production")
 
-    if pr_number:
-        if "run-jenkins-tests" in labels:
-            display("PR labeled to run Jenkins tests instead of Konflux")
-            return
-
-        if "ok-to-skip-smokes" in labels:
-            display("PR labeled to skip smoke tests")
-            return
-
-        if "koku" in snapshot_components and "smokes-required" in labels and not any(label.endswith("smoke-tests") for label in labels):
-            sys.exit("Missing smoke tests labels.")
-
-    else:
-        display("[INFO] No PR number found. Assuming nightly/manual test run.")
-        display("[INFO] Proceeding with full smoke tests...")
+    if not _should_deploy(pr_number, labels, snapshot_components):
+        return
 
     for secret in ["koku-aws", "koku-gcp"]:
         cmd = f"oc get secret {secret} -o yaml -n ephemeral-base | grep -v '^\s*namespace:\s' | oc apply --namespace={namespace} -f -"


### PR DESCRIPTION
## Jira Ticket
[COST-7391](https://issues.redhat.com/browse/COST-7391)

## Description

PRs from forks don't receive automatic labels because the GitHub Actions `GITHUB_TOKEN` is read-only for fork PRs. The `smokes-labeler` job fails silently (`continue-on-error: true`), leaving the PR with no labels at all.

Previously, when no labels were found, the pipeline assumed it was a scheduled/manual run and proceeded with **full smoke tests** — consuming cloud test accounts (AWS, Azure, GCP) unnecessarily and causing resource exhaustion ("No unused Azure account" errors).

This change adds a check in both `deploy.py` and `deploy-iqe-cji.py`: if a PR number is present but no labels exist, the pipeline exits with an error instead of running full smokes. This requires explicit label assignment before smoke tests can run.

Scheduled jobs, manual runs, and push-to-main events (no PR number) continue to run full smoke tests as before.

### Scenario matrix

| Scenario | PR number | Labels | Result |
|---|---|---|---|
| PR with auto-labels (internal branch) | set | `{smokes-required, smoke-tests}` | Runs smokes per labels |
| **PR without labels (fork)** | set | empty | **`sys.exit` — red** |
| PR with `ok-to-skip-smokes` | set | `{ok-to-skip-smokes}` | Skips smokes |
| Scheduled job (cronjob) | empty | empty | Full smokes (unchanged) |
| Push to main | empty | empty | Full smokes (unchanged) |
| Manual trigger | empty | empty | Full smokes (unchanged) |

## Testing

1. Checkout this branch
2. Verify with `--check` flag that a PR with labels continues to produce correct bonfire commands
3. Verify that a PR with no labels exits with error message
4. Verify that a run without PR number (simulating scheduled job) proceeds normally
