### PR TITLE
[COST-7408] Exclude Trino from components when on-prem-processing label is set

### DIFF
--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -50,12 +50,11 @@ def get_batch_size_from_label(labels: set[str] | None) -> str | None:
 
 
 def get_on_prem_toggle_from_label(labels: set[str] | None) -> bool:
-    """Search labels for 'ocp-on-prem-smoke-tests' or "on-prem-processing" and return True if valid/False otherwise"""
+    """Search labels for 'on-prem-processing' and return True if found, False otherwise."""
     if not labels:
         return False
 
-    on_prem_processing_label = "on-prem-processing"
-    return on_prem_processing_label in labels
+    return "on-prem-processing" in labels
 
 
 def get_component_options(components: list[Component], pr_number: str | None = None, labels: set[str] | None = None) -> list[str]:
@@ -214,7 +213,10 @@ def main() -> None:
         display("[INFO] EVENT_TYPE missing, but PR_NUMBER is set; treating run as PR context.")
     labels = get_pr_labels(pr_number, owner=owner, repo=repo) if pr_number else []
     app_name = os.environ.get("APP_NAME")
-    components = os.environ.get("COMPONENTS", "").split()
+    on_prem = get_on_prem_toggle_from_label(labels)
+    components = [c for c in os.environ.get("COMPONENTS", "").split() if not (on_prem and c == "trino")]
+    if on_prem:
+        print(f"[INFO] on-prem-processing label detected: excluding 'trino' from components. Components: {components}")
     components_arg = chain.from_iterable(("--component", component) for component in components)
     components_with_resources = os.environ.get("COMPONENTS_W_RESOURCES", "").split()
     components_with_resources_arg = chain.from_iterable(("--no-remove-resources", component) for component in components_with_resources)

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -216,7 +216,7 @@ def main() -> None:
     on_prem = get_on_prem_toggle_from_label(labels)
     components = [c for c in os.environ.get("COMPONENTS", "").split() if not (on_prem and c == "trino")]
     if on_prem:
-        print(f"[INFO] on-prem-processing label detected: excluding 'trino' from components. Components: {components}")
+        display(f"[INFO] on-prem-processing label detected: excluding 'trino' from components. Components: {components}")
     components_arg = chain.from_iterable(("--component", component) for component in components)
     components_with_resources = os.environ.get("COMPONENTS_W_RESOURCES", "").split()
     components_with_resources_arg = chain.from_iterable(("--no-remove-resources", component) for component in components_with_resources)

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -244,8 +244,10 @@ def main() -> None:
         "--set-parameter", "sources-api/MIN_REPLICAS=1",
         "--set-parameter", "sources-api/BACKGROUND_WORKER_MIN_REPLICAS=0",
         "--set-parameter", "sources-api/AVAILABILITY_MIN_REPLICAS=0",
-        "--set-parameter", "trino/HIVE_PROPERTIES_FILE=glue.properties",
-        "--set-parameter", "trino/GLUE_PROPERTIES_FILE=hive.properties",
+        *([] if on_prem else [
+            "--set-parameter", "trino/HIVE_PROPERTIES_FILE=glue.properties",
+            "--set-parameter", "trino/GLUE_PROPERTIES_FILE=hive.properties",
+        ]),
         *components_arg,
         *components_with_resources_arg,
         *extra_deploy_args.split(),


### PR DESCRIPTION
## Jira Ticket
[COST-7408](https://issues.redhat.com/browse/COST-7408)

## Description

This change will exclude `trino` from the list of deployed components when the `on-prem-processing` PR label is detected.

The `ONPREM=True` processing path uses only PostgreSQL (`self_hosted_sql/`) and never touches the Trino/Parquet/S3 pipeline. Deploying Trino in ephemeral environments for on-prem runs wastes time and resources with no benefit.

**Changes:**
- In `deploy.py`, when `on-prem-processing` label is detected, `trino` is filtered out of `COMPONENTS` before passing to bonfire
- Fixed stale docstring on `get_on_prem_toggle_from_label` (previously referenced `ocp-on-prem-smoke-tests` which was never actually checked)

**Behaviour by scenario:**

| PR label | COMPONENTS (ITS) | Deployed to bonfire |
|---|---|---|
| _(none)_ / `ocp-smokes` | `koku trino` | `koku trino` (unchanged) |
| `on-prem-processing` | `koku trino` | `koku` (trino excluded) |
| `on-prem-processing` | `koku` | `koku` (no effect) |

## Testing

1. Checkout branch
2. Open a PR on `koku` with the `on-prem-processing` label
3. Observe the Konflux pipeline logs in the `deploy-application` step
   - You should see: `[INFO] on-prem-processing label detected: excluding 'trino' from components. Components: ['koku']`
   - The bonfire deploy command should NOT include `--component trino`
4. Confirm `cost_ocp_on_prem` tests pass without Trino deployed

## Release Notes
- [ ] proposed release note

```
* [COST-7408](https://issues.redhat.com/browse/COST-7408) Exclude Trino from ephemeral env when on-prem-processing label is set
```

Made with [Cursor](https://cursor.com)