### PR TITLE
COST-7485: Scope no-label gate to koku component only

### DIFF
--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -267,12 +267,14 @@ class IQERunner:
                 display("PR labeled to skip smoke tests")
                 return
 
-            if "smokes-required" in self.pr_labels and not any(label.endswith("smoke-tests") for label in self.pr_labels):
+            if "koku" in self.snapshot_components and "smokes-required" in self.pr_labels and not any(label.endswith("smoke-tests") for label in self.pr_labels):
                 sys.exit("Missing smoke tests labels.")
         elif self.pr_number and "koku" in self.snapshot_components:
             sys.exit(f"[ERROR] No labels found on PR #{self.pr_number}. Add a smoke test label (e.g., smoke-tests, ok-to-skip-smokes) to proceed.")
+        elif self.pr_number:
+            display(f"[INFO] No PR labels found for PR #{self.pr_number}. Proceeding with deploy (non-koku component).")
         else:
-            display("[INFO] No PR labels found. Assuming this is a scheduled or manual test run.")
+            display("[INFO] No PR number found. Assuming nightly/manual test run.")
             display("[INFO] Proceeding with full smoke tests...")
 
         self.run_pod()

--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -267,7 +267,11 @@ class IQERunner:
                 display("PR labeled to skip smoke tests")
                 return
 
-            if "koku" in self.snapshot_components and "smokes-required" in self.pr_labels and not any(label.endswith("smoke-tests") for label in self.pr_labels):
+            if (
+                "koku" in self.snapshot_components
+                and "smokes-required" in self.pr_labels
+                and not any(label.endswith("smoke-tests") for label in self.pr_labels)
+            ):
                 sys.exit("Missing smoke tests labels.")
         elif self.pr_number and "koku" in self.snapshot_components:
             sys.exit(f"[ERROR] No labels found on PR #{self.pr_number}. Add a smoke test label (e.g., smoke-tests, ok-to-skip-smokes) to proceed.")

--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -189,6 +189,10 @@ class IQERunner:
         return get_timeout("IQE_CJI_TIMEOUT", self.pr_labels)
 
     @cached_property
+    def snapshot_components(self) -> set[str]:
+        return {component.name for component in self.snapshot.components}
+
+    @cached_property
     def pr_labels(self) -> set[str]:
         if self.check:
             return set(os.environ.get("PR_LABELS", "").split()) or {"run-konflux-tests", "hot-fix-smoke-tests", "bug"}
@@ -265,7 +269,7 @@ class IQERunner:
 
             if "smokes-required" in self.pr_labels and not any(label.endswith("smoke-tests") for label in self.pr_labels):
                 sys.exit("Missing smoke tests labels.")
-        elif self.pr_number:
+        elif self.pr_number and "koku" in self.snapshot_components:
             sys.exit(f"[ERROR] No labels found on PR #{self.pr_number}. Add a smoke test label (e.g., smoke-tests, ok-to-skip-smokes) to proceed.")
         else:
             display("[INFO] No PR labels found. Assuming this is a scheduled or manual test run.")

--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -274,7 +274,7 @@ class IQERunner:
         elif self.pr_number:
             display(f"[INFO] No PR labels found for PR #{self.pr_number}. Proceeding with deploy (non-koku component).")
         else:
-            display("[INFO] No PR number found. Assuming nightly/manual test run.")
+            display("[INFO] No PR number found. Assuming scheduled/manual test run.")
             display("[INFO] Proceeding with full smoke tests...")
 
         self.run_pod()

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -174,7 +174,7 @@ def _should_deploy(pr_number: str, labels: set[str] | list, snapshot_components:
         if "koku" in snapshot_components and "smokes-required" in labels and not any(label.endswith("smoke-tests") for label in labels):
             sys.exit("Missing smoke tests labels.")
 
-        if not labels:
+        if not labels and "koku" in snapshot_components:
             sys.exit(f"[ERROR] No labels found on PR #{pr_number}. Add a smoke test label (e.g., smoke-tests, ok-to-skip-smokes) to proceed.")
 
     else:


### PR DESCRIPTION
## Jira Ticket
[COST-7485](https://issues.redhat.com/browse/COST-7485)

## Description

The label gate added in [#84](https://github.com/project-koku/koku-test-container/pull/84) (COST-7391) was too broad: it blocked any PR without labels in **any repo** that uses this container, even repos that don't configure `smokes-labeler` (e.g., `nise-populator`, `trino`).

Error seen in those repos:
```
[ERROR] No labels found on PR #N. Add a smoke test label (e.g., smoke-tests, ok-to-skip-smokes) to proceed.
```

This fix narrows the check so it only fails when `koku` is present in the snapshot components, leaving other repos unaffected.

## Changes

- `deploy.py`: `if not labels` → `if not labels and "koku" in snapshot_components`
- `deploy-iqe-cji.py`: `elif self.pr_number` → `elif self.pr_number and "koku" in self.snapshot_components` + added `snapshot_components` cached property

## Testing

| Scenario | Expected |
|---|---|
| koku PR without labels | ❌ Blocked (unchanged) |
| koku PR with labels | ✅ Proceeds (unchanged) |
| nise-populator PR without labels | ✅ Proceeds (fixed) |
| trino PR without labels | ✅ Proceeds (fixed) |

Made with [Cursor](https://cursor.com)