### PR TITLE
Make SCHEMA_SUFFIX unique per PipelineRun (STONEINTG-1732 mitigation)

### DIFF
--- a/files/bin/deploy-iqe-cji.py
+++ b/files/bin/deploy-iqe-cji.py
@@ -15,6 +15,7 @@ import sh
 from deploy import display
 from deploy import get_batch_size_from_label
 from deploy import get_pr_labels
+from deploy import get_schema_run_identifier
 from deploy import get_timeout
 from models import Snapshot
 from pydantic import ValidationError
@@ -76,10 +77,12 @@ class IQERunner:
 
     @cached_property
     def schema_suffix(self) -> str:
+        # Must match deploy.py's koku/SCHEMA_SUFFIX so the app and IQE share a schema.
+        # Use per-PipelineRun id (not check_run_id) so STONEINTG-1732 duplicates do not collide.
         # assume the component we care about is first!
         revision = self.snapshot.components[0].source.git.revision[:7]
         prefix = f"pr-{self.pr_number}-" if self.pr_number else ""
-        return f"SCHEMA_SUFFIX=_{prefix}{revision}_{self.check_run_id}"
+        return f"SCHEMA_SUFFIX=_{prefix}{revision}_{get_schema_run_identifier()}"
 
     @cached_property
     def build_url(self) -> str:

--- a/files/bin/deploy.py
+++ b/files/bin/deploy.py
@@ -31,6 +31,26 @@ def get_check_run_identifier() -> str:
     return "1"
 
 
+def get_schema_run_identifier() -> str:
+    """Return a per-PipelineRun id for SCHEMA_SUFFIX uniqueness.
+
+    Prefer the Tekton-generated suffix of PIPELINE_RUN_NAME (e.g. ``vjftk`` from
+    ``koku-ci-vjftk``) so concurrent duplicate integration PipelineRuns for the
+    same Snapshot (STONEINTG-1732) do not share a Postgres schema.
+
+    Falls back to CHECK_RUN_ID[:5] (or ``1``) when PIPELINE_RUN_NAME is unset or
+    does not look like a generateName result.
+    """
+    pipeline_run_name = os.environ.get("PIPELINE_RUN_NAME", "").strip()
+    if pipeline_run_name and "-" in pipeline_run_name:
+        # generateName yields "<scenario>-<random>"; use the random segment.
+        suffix = pipeline_run_name.rsplit("-", 1)[-1]
+        if suffix.isalnum():
+            return suffix
+
+    return get_check_run_identifier()
+
+
 def get_batch_size_from_label(labels: set[str] | None) -> str | None:
     """Search labels for 'adjust-batch-size=VALUE' and return VALUE if valid."""
     if not labels:
@@ -60,7 +80,7 @@ def get_on_prem_toggle_from_label(labels: set[str] | None) -> bool:
 def get_component_options(components: list[Component], pr_number: str | None = None, labels: set[str] | None = None) -> list[str]:
     """Build bonfire options for each component in the snapshot."""
     built_component_name = os.environ.get("BONFIRE_COMPONENT_NAME") or ""
-    check_run_id = get_check_run_identifier()
+    schema_run_id = get_schema_run_identifier()
     batch_size_value = get_batch_size_from_label(labels)
     on_prem_toggle = get_on_prem_toggle_from_label(labels)
     result = []
@@ -91,7 +111,7 @@ def get_component_options(components: list[Component], pr_number: str | None = N
         if component_name == "koku":
             result.extend((
                 "--set-parameter",
-                f"{component_name}/SCHEMA_SUFFIX=_{prefix}{revision}_{check_run_id}",
+                f"{component_name}/SCHEMA_SUFFIX=_{prefix}{revision}_{schema_run_id}",
             ))
 
             # Adjust PARQUET_PROCESSING_BATCH_SIZE via adjust-batch-size GITHUB label


### PR DESCRIPTION
## Summary
- Mitigate [STONEINTG-1732](https://redhat.atlassian.net/browse/STONEINTG-1732): when Integration Service creates multiple `koku-ci-*` PipelineRuns for the same Snapshot, they previously shared `SCHEMA_SUFFIX` (built from `check-run-id` + git sha) and stomped on the same Postgres schema.
- Prefer the Tekton `generateName` suffix from `PIPELINE_RUN_NAME` (e.g. `koku-ci-vjftk` → `vjftk`) for `SCHEMA_SUFFIX` in **both** `deploy.py` (app) and `deploy-iqe-cji.py` (IQE), so they stay aligned.
- Fall back to `CHECK_RUN_ID[:5]` / `1` when `PIPELINE_RUN_NAME` is missing (same as before).

## Edge cases reviewed
| Case | Behavior |
|------|----------|
| Normal PR (`koku-ci-<rand>`) | Unique schema per PLR |
| Duplicate PLRs (same Snapshot) | Different schemas → no collision |
| Scheduled jobs (`koku-scheduled-*-<rand>`) | Uses PLR suffix; still unique |
| On-prem PR label (`ONPREM=True` on `koku`) | Unchanged path; same unique suffix |
| Missing `PIPELINE_RUN_NAME` | Falls back to check-run-id (legacy) |
| Length / Postgres id | Suffix stays ~5 alphanumeric chars (same size as before) |
| Ibutsu `BUILD_NUMBER` | Still uses `check_run_id` (not changed) |

**Out of scope / pre-existing:** `SCHEMA_SUFFIX` is only set on deploy when `component_name == "koku"`. The `koku-onprem` application path (COMPONENT_NAME=`koku-onprem`) did not set deploy SCHEMA_SUFFIX before and is unchanged.

This does **not** stop Konflux from spawning duplicate PLRs (that is STONEINTG-1732). It only prevents those duplicates from sharing a DB schema.

## Test plan
- [ ] Unit-style checks of `get_schema_run_identifier()` (PR/duplicate/scheduled/fallback) — done locally
- [ ] After image rebuild/push (`:latest` or ITS pin): run a koku PR smoke and confirm deploy log shows `SCHEMA_SUFFIX=_pr-<n>-<sha>_<plrSuffix>` matching the PipelineRun name suffix
- [ ] Confirm IQE env has the same `SCHEMA_SUFFIX` as the deployed koku param
- [ ] On-prem smoke (`ocp-on-prem-smoke-tests` or scheduled onprem) still deploys and runs
- [ ] Optional: if duplicate PLRs appear again, verify they use different schemas and do not fail solely due to schema collision


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Ensure database schema suffixes are unique per PipelineRun to prevent collisions when multiple runs are created for the same snapshot.

Bug Fixes:
- Prevent concurrent duplicate PipelineRuns from sharing the same Postgres schema by using a per-run identifier in SCHEMA_SUFFIX.

Enhancements:
- Derive SCHEMA_SUFFIX from the Tekton-generated PipelineRun name suffix and reuse the same identifier across application deploy and IQE jobs for alignment.